### PR TITLE
Add some benchmarks with unicode characters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         sudo apt-get install clang-format-17
     - name: "Clang-format libtermbench"
       run: find ./libtermbench -name "*.cpp" -o -name "*.h" | xargs clang-format-17 --Werror --dry-run
-    - name: "Clang-format tb1"
+    - name: "Clang-format tb"
       run: find ./tb -name "*.cpp" -o -name "*.h" | xargs clang-format-17 --Werror --dry-run
     - name: "Check includes"
       run: ./scripts/check-includes.sh
@@ -93,18 +93,14 @@ jobs:
       run: cargo install alacritty
     - name: "Install kitty and xterm"
       run: sudo apt install -y kitty xterm xvfb
-    - name: "run benchmarks"
+    - name: "Install wezterm"
+      run: |
+        curl -fsSL https://apt.fury.io/wez/gpg.key | sudo gpg --yes --dearmor -o /usr/share/keyrings/wezterm-fury.gpg
+        echo 'deb [signed-by=/usr/share/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *' | sudo tee /etc/apt/sources.list.d/wezterm.list
+        sudo apt update
+        sudo apt install wezterm
+    - name: "Run benchmarks"
       run: ./scripts/Xvfb-bench-run.sh "./build/$CMAKE_PRESET/tb/tb"
-    - name: "ls"
-      run: ls -la
-    - name: "cat contour_results"
-      run: cat contour_results
-    - name: "cat kitty_results"
-      run: cat kitty_results
-    - name: "cat xterm_results"
-      run: cat xterm_results
-    - name: "cat alacritty_results"
-      run: cat alacritty_results
     - name: "Set up Julia"
       uses: julia-actions/setup-julia@v1
     - name: "Create Plots"

--- a/libtermbench/termbench.cpp
+++ b/libtermbench/termbench.cpp
@@ -421,32 +421,101 @@ std::unique_ptr<Test> binary()
     return std::make_unique<Binary>();
 }
 
-std::unique_ptr<Test> ascii_line(size_t N)
+std::unique_ptr<Test> ascii_line(size_t line_length)
 {
-    auto name = std::to_string(N) + " chars per line";
-    auto text = std::string(N, 'a') + std::string { "\n" };
+    auto name = std::to_string(line_length) + " chars per line";
+    auto text = std::string(line_length, 'a') + std::string { "\n" };
     return std::make_unique<Line>(name, text);
 }
 
-std::unique_ptr<Test> sgr_line(size_t N)
+std::unique_ptr<Test> sgr_line(size_t line_length)
 {
-    auto name = std::to_string(N) + " chars with sgr per line";
+    auto name = std::to_string(line_length) + " chars with sgr per line";
     std::string text {};
-    text += std::string { "\033[38;2;20;200;200m" };
-    text += std::string(N, 'a');
-    text += std::string { "\n" };
-    text += std::string { "\033[38;2;255;255;255m" };
+    text += "\033[38;2;20;200;200m";
+    text += std::string(line_length, 'a');
+    text += "\n";
+    text += "\033[38;2;255;255;255m";
     return std::make_unique<Line>(name, text);
 }
 
-std::unique_ptr<Test> sgrbg_line(size_t N)
+std::unique_ptr<Test> sgrbg_line(size_t line_length)
 {
-    auto name = std::to_string(N) + " chars with sgr and bg per line";
+    auto name = std::to_string(line_length) + " chars with sgr and bg per line";
     std::string text {};
-    text += std::string { "\033[38;2;20;200;200m\033[48;2;100;100;100m" };
-    text += std::string(N, 'a');
-    text += std::string { "\033[38;2;255;255;255m\033[48;2;0;0;0m" };
+    text += "\033[38;2;20;200;200m\033[48;2;100;100;100m";
+    text += std::string(line_length, 'a');
+    text += "\033[38;2;255;255;255m\033[48;2;0;0;0m";
+    text += "\n";
+    return std::make_unique<Line>(name, text);
+}
+
+std::unique_ptr<Test> unicode_simple(size_t line_length)
+{
+    auto name = std::to_string(line_length) + " unicode simple";
+    std::string text {};
+    for (size_t i = 0; i < line_length; ++i)
+        text += "\u0061";
+    text += "\n";
+    return std::make_unique<Line>(name, text);
+}
+
+std::unique_ptr<Test> unicode_two_codepoints(size_t line_length)
+{
+    auto name = std::to_string(line_length) + " unicode diacritic";
+    std::string text {};
+    for (size_t i = 0; i < line_length; ++i)
+        text += "\u0061\u0308";
+    text += "\n";
+    return std::make_unique<Line>(name, text);
+}
+
+std::unique_ptr<Test> unicode_three_codepoints(size_t line_length)
+{
+    auto name = std::to_string(line_length) + " unicode double diacritic";
+    std::string text {};
+    for (size_t i = 0; i < static_cast<size_t>(line_length / 2); ++i)
+        text += "\u0061\u035D\u0062";
+    text += "\n";
+    return std::make_unique<Line>(name, text);
+}
+
+std::unique_ptr<Test> unicode_fire_as_text(size_t line_length)
+{
+    auto name = std::to_string(line_length) + " unicode fire as text";
+    std::string text {};
+    for (size_t i = 0; i < static_cast<size_t>(line_length / 2); ++i)
+        text += std::string { "\U0001F525\U0000FE0E" };
     text += std::string { "\n" };
+    return std::make_unique<Line>(name, text);
+}
+
+std::unique_ptr<Test> unicode_fire(size_t line_length)
+{
+    auto name = std::to_string(line_length) + " unicode fire";
+    std::string text {};
+    for (size_t i = 0; i < static_cast<size_t>(line_length / 2); ++i)
+        text += std::string { "\U0001F525" };
+    text += std::string { "\n" };
+    return std::make_unique<Line>(name, text);
+}
+
+std::unique_ptr<Test> unicode_flag(size_t line_length)
+{
+    auto name = std::to_string(line_length) + " unicode flag";
+    std::string text {};
+    std::string flag {};
+    flag += "\U0001F3F4";
+    flag += "\U000E0067";
+    flag += "\U000E0062";
+    flag += "\U000E0065";
+    flag += "\U000E006E";
+    flag += "\U000E0067";
+    flag += "\U000E007F";
+
+    for (size_t i = 0; i < static_cast<size_t>(line_length / 2); ++i)
+        text += flag;
+    text += "\n";
     return std::make_unique<Line>(name, text);
 }
 

--- a/libtermbench/termbench.h
+++ b/libtermbench/termbench.h
@@ -127,5 +127,11 @@ std::unique_ptr<Test> binary();
 std::unique_ptr<Test> ascii_line(size_t);
 std::unique_ptr<Test> sgr_line(size_t);
 std::unique_ptr<Test> sgrbg_line(size_t);
+std::unique_ptr<Test> unicode_simple(size_t);
+std::unique_ptr<Test> unicode_two_codepoints(size_t);
+std::unique_ptr<Test> unicode_three_codepoints(size_t);
+std::unique_ptr<Test> unicode_flag(size_t);
+std::unique_ptr<Test> unicode_fire_as_text(size_t); // U+FEOE
+std::unique_ptr<Test> unicode_fire(size_t);
 std::unique_ptr<Test> crafted(std::string name, std::string description, std::string text);
 } // namespace termbench::tests

--- a/scripts/Xvfb-bench-run.sh
+++ b/scripts/Xvfb-bench-run.sh
@@ -8,6 +8,7 @@ CONTOUR_BIN="${CONTOUR_BIN:-contour}"
 KITTY_BIN="${KITTY_BIN:-kitty}"
 XTERM_BIN="${XTERM_BIN:-xterm}"
 ALACRITTY_BIN="${ALACRITTY_BIN:-alacritty}"
+WEZTERM_BIN="${WEZTERM_BIN:-wezterm}"
 FB_DISPLAY="${FB_DISPLAY:-:99}"
 
 OUTPUT_DIR="${PWD}"
@@ -31,6 +32,7 @@ require_bin "${CONTOUR_BIN}"
 require_bin "${KITTY_BIN}"
 require_bin "${XTERM_BIN}"
 require_bin "${ALACRITTY_BIN}"
+require_bin "${WEZTERM_BIN}"
 
 export TB_BIN=$(realpath $TB_BIN)
 export DISPLAY=${FB_DISPLAY}
@@ -47,12 +49,9 @@ function program_exit() {
 function bench_terminal() {
     printf "\033[1m==> Running terminal: $1\033[m\n"
     local terminal_name=$(basename $1)
-    time "${@}" -e "${TB_BIN}" --fixed-size --stdout-fastpath --column-by-column --output "${OUTPUT_DIR}/${terminal_name}_results"
+    time "${@}" -e "${TB_BIN}" --fixed-size --column-by-column --size 2 --output "${OUTPUT_DIR}/${terminal_name}_results"
     local exit_code=$?
     printf "\033[1m==> Terminal exit code: $exit_code\033[m\n"
-    if [[ $exit_code -ne 0 ]]; then
-        program_exit $exit_code
-    fi
 }
 
 set -x
@@ -67,5 +66,6 @@ bench_terminal "${CONTOUR_BIN}" display ${DISPLAY}
 bench_terminal "${KITTY_BIN}"
 bench_terminal "${XTERM_BIN}" -display ${DISPLAY}
 bench_terminal "${ALACRITTY_BIN}"
+bench_terminal "${WEZTERM_BIN}"
 
 program_exit 0


### PR DESCRIPTION
- [x]  single codepoint grapheme clusters (aka. US-ASCII) should always be the fastest.
- [x]  Diacritic
- [x]  Diacritic for two codepoints
- [x]  U+FE0F (VS16) for narrow-width GCs may affect perf due to width change (Diacritic)
- [ ]  invalid UTF-8 sequences might severily impact performance for 2 reasons (parsing as well as rendering that can impact parsing, depending on how a TE is implementing it)